### PR TITLE
echo-server: add service annotations

### DIFF
--- a/chart_schema.yaml
+++ b/chart_schema.yaml
@@ -3,6 +3,7 @@
 name: str()
 home: str(required=False)
 version: str()
+appVersion: any(str(), num(), required=False)
 apiVersion: str()
 description: str()
 keywords: list(str(), required=False)

--- a/charts/echo-server/templates/service.yaml
+++ b/charts/echo-server/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "echo-server.fullname" . }}
   labels:
     {{- include "echo-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/echo-server/values.yaml
+++ b/charts/echo-server/values.yaml
@@ -39,6 +39,7 @@ nameOverride: ""
 service:
   type: ClusterIP
   port: 80
+  # annotations: {}
 
 ingress:
   class: "nginx"


### PR DESCRIPTION
## what

- adds option to add annotations to service manifest for `echo-server`

## why

- so that the service annotations can be customized via `values.yaml`
